### PR TITLE
Event list fixes in Dashboard.Header

### DIFF
--- a/DLPrototype.xcodeproj/project.pbxproj
+++ b/DLPrototype.xcodeproj/project.pbxproj
@@ -139,6 +139,7 @@
 		53E202702A80984400B4DF70 /* DateSelectorWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E2026F2A80984400B4DF70 /* DateSelectorWidget.swift */; };
 		53E202722A80BAD500B4DF70 /* ButtonType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E202712A80BAD500B4DF70 /* ButtonType.swift */; };
 		53E202762A81F2E100B4DF70 /* FancyStar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E202752A81F2E100B4DF70 /* FancyStar.swift */; };
+		53E24C412A844BC800EB21FD /* EKEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E24C402A844BC800EB21FD /* EKEvent.swift */; };
 		53ECD0572971F8F400A09AAB /* CoreDataRecords.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53ECD0562971F8F400A09AAB /* CoreDataRecords.swift */; };
 		53EDDF9E29634852008D34C7 /* Entry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53EDDF9D29634852008D34C7 /* Entry.swift */; };
 		53EDDFA02963487A008D34C7 /* CustomPickerItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53EDDF9F2963487A008D34C7 /* CustomPickerItem.swift */; };
@@ -316,6 +317,7 @@
 		53E2026F2A80984400B4DF70 /* DateSelectorWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateSelectorWidget.swift; sourceTree = "<group>"; };
 		53E202712A80BAD500B4DF70 /* ButtonType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonType.swift; sourceTree = "<group>"; };
 		53E202752A81F2E100B4DF70 /* FancyStar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FancyStar.swift; sourceTree = "<group>"; };
+		53E24C402A844BC800EB21FD /* EKEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EKEvent.swift; sourceTree = "<group>"; };
 		53ECD0562971F8F400A09AAB /* CoreDataRecords.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataRecords.swift; sourceTree = "<group>"; };
 		53EDDF9D29634852008D34C7 /* Entry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Entry.swift; sourceTree = "<group>"; };
 		53EDDF9F2963487A008D34C7 /* CustomPickerItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomPickerItem.swift; sourceTree = "<group>"; };
@@ -873,6 +875,7 @@
 				53EFCE7529637CC6004E45EC /* Color.swift */,
 				53152CC829690E7300A14E43 /* LosslessStringConvertible.swift */,
 				5363B67F2A6DE87000C2FBB8 /* View.swift */,
+				53E24C402A844BC800EB21FD /* EKEvent.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1097,6 +1100,7 @@
 				537368D124B93DB600193E88 /* Today.swift in Sources */,
 				537628AC29665B4E00DE8ECF /* NoteView.swift in Sources */,
 				53B0BE8829726400007CB663 /* GenericToolbar.swift in Sources */,
+				53E24C412A844BC800EB21FD /* EKEvent.swift in Sources */,
 				53999C1F29669C4E00125E65 /* NoteCreate.swift in Sources */,
 				53E202682A802D0900B4DF70 /* ButtonSize.swift in Sources */,
 				53759E0D2967ECAE00DCDC4B /* LogRecords.swift in Sources */,

--- a/DLPrototype/DLPrototype.swift
+++ b/DLPrototype/DLPrototype.swift
@@ -14,6 +14,7 @@ struct DLPrototype: App {
     private let persistenceController = PersistenceController.shared
     @StateObject public var updater: ViewUpdater = ViewUpdater()
     @StateObject public var nav: Navigation = Navigation()
+    @StateObject public var ce: CoreDataCalendarEvent = CoreDataCalendarEvent(moc: PersistenceController.shared.container.viewContext)
     
     @Environment(\.scenePhase) var scenePhase
     
@@ -23,6 +24,7 @@ struct DLPrototype: App {
                 .environment(\.managedObjectContext, persistenceController.container.viewContext)
                 .environmentObject(updater)
                 .environmentObject(nav)
+                .environmentObject(ce)
                 .onAppear(perform: onAppear)
                 .onChange(of: scenePhase) { _ in
                     persistenceController.save()
@@ -36,11 +38,11 @@ struct DLPrototype: App {
             MainMenu(moc: persistenceController.container.viewContext, nav: nav)
         }
 
-        
         #if os(macOS)
         Settings {
             SettingsView()
                 .environment(\.managedObjectContext, persistenceController.container.viewContext)
+                .environmentObject(ce)
         }
         
         // TODO: temp commented out, too early to include this

--- a/DLPrototype/DLPrototype.swift
+++ b/DLPrototype/DLPrototype.swift
@@ -43,6 +43,7 @@ struct DLPrototype: App {
             SettingsView()
                 .environment(\.managedObjectContext, persistenceController.container.viewContext)
                 .environmentObject(ce)
+                .environmentObject(nav)
         }
         
         // TODO: temp commented out, too early to include this

--- a/DLPrototype/Extensions/EKEvent.swift
+++ b/DLPrototype/Extensions/EKEvent.swift
@@ -1,0 +1,19 @@
+//
+//  EKEvent.swift
+//  DLPrototype
+//
+//  Created by Ryan Priebe on 2023-08-09.
+//  Copyright © 2023 YegCollective. All rights reserved.
+//
+
+import Foundation
+import EventKit
+
+extension EKEvent {
+    func startTime() -> String {
+        let df = DateFormatter()
+        df.dateFormat = "h:mm a"
+
+        return df.string(from: self.startDate)
+    }
+}

--- a/DLPrototype/Models/CoreData/CoreDataCalendarEvent.swift
+++ b/DLPrototype/Models/CoreData/CoreDataCalendarEvent.swift
@@ -172,8 +172,6 @@ public class CoreDataCalendarEvent: ObservableObject {
                 }
             }
 
-//            let _ = self.store(events: ekEvents, type: .upcoming)
-
             return ekEvents
         }
     }

--- a/DLPrototype/Utils/ViewUpdater.swift
+++ b/DLPrototype/Utils/ViewUpdater.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 public class ViewUpdater: ObservableObject {
+    // TODO: this is gross, try to remove it
     @Published public var ids: [String: UUID] = [
         "today.table": UUID(),
         "today.picker": UUID(),
@@ -32,6 +33,7 @@ public class ViewUpdater: ObservableObject {
         "project.dashboard": UUID(),
         "project.view": UUID(),
         "job.dashboard": UUID(),
+        "dashboard.header": UUID(),
     ]
 
     public func get(_ key: String) -> UUID {

--- a/DLPrototype/Views/Dashboard/Dashboard.swift
+++ b/DLPrototype/Views/Dashboard/Dashboard.swift
@@ -63,7 +63,6 @@ extension Dashboard {
 
                     VStack(alignment: .leading) {
                         Title(text: "Welcome back!")
-//                        FancyDivider()
 
                         if calendar > -1 {
                             HStack {
@@ -77,9 +76,11 @@ extension Dashboard {
                                 VStack(alignment: .leading) {
                                     ForEach(upcomingEvents, id: \.self) { event in
                                         HStack {
-                                            Image(systemName: "arrow.right")
+                                            let hasPassed = event.startDate >= Date()
+                                            Image(systemName: hasPassed ? "arrow.right" : "checkmark")
                                                 .padding(.leading, 15)
                                             Text("\(event.title) at \(event.startTime())")
+                                                .foregroundColor(hasPassed ? .white : .gray)
                                         }
                                     }
                                 }

--- a/DLPrototype/Views/Dashboard/Dashboard.swift
+++ b/DLPrototype/Views/Dashboard/Dashboard.swift
@@ -45,6 +45,7 @@ extension Dashboard {
 extension Dashboard {
     struct Header: View {
         @State private var upcomingEvents: [EKEvent] = []
+        @State private var calendarName: String = ""
         
         @EnvironmentObject public var nav: Navigation
         @EnvironmentObject public var ce: CoreDataCalendarEvent
@@ -62,11 +63,27 @@ extension Dashboard {
 
                     VStack(alignment: .leading) {
                         Title(text: "Welcome back!")
-                        FancyDivider()
+//                        FancyDivider()
 
                         if calendar > -1 {
-                            Text("You have \(upcomingEvents.count) meetings today")
-                                .font(Theme.font)
+                            HStack {
+                                Image(systemName: "calendar")
+                                Text("You have \(upcomingEvents.count) meetings today")
+                                    .font(Theme.font)
+                            }
+                            .padding(5)
+
+                            if upcomingEvents.count <= 3 {
+                                VStack(alignment: .leading) {
+                                    ForEach(upcomingEvents, id: \.self) { event in
+                                        HStack {
+                                            Image(systemName: "arrow.right")
+                                                .padding(.leading, 15)
+                                            Text("\(event.title) at \(event.startTime())")
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                     .padding()
@@ -81,7 +98,8 @@ extension Dashboard {
 extension Dashboard.Header {
     private func actionOnAppear() -> Void {
         if let chosenCalendar = ce.selectedCalendar() {
-            upcomingEvents = ce.eventsUpcoming(chosenCalendar)
+            calendarName = chosenCalendar
+            upcomingEvents = ce.events(chosenCalendar)
         }
     }
 }

--- a/DLPrototype/Views/Home/Home.swift
+++ b/DLPrototype/Views/Home/Home.swift
@@ -12,11 +12,11 @@ struct Home: View {
     @Environment(\.managedObjectContext) var moc
     @EnvironmentObject public var updater: ViewUpdater
     @EnvironmentObject public var nav: Navigation
+    @EnvironmentObject public var ce: CoreDataCalendarEvent
     
     @StateObject public var rm: LogRecords = LogRecords(moc: PersistenceController.shared.container.viewContext)
     @StateObject public var jm: CoreDataJob = CoreDataJob(moc: PersistenceController.shared.container.viewContext)
     @StateObject public var crm: CoreDataRecords = CoreDataRecords(moc: PersistenceController.shared.container.viewContext)
-    @StateObject public var ce: CoreDataCalendarEvent = CoreDataCalendarEvent(moc: PersistenceController.shared.container.viewContext)
     @StateObject public var pr: CoreDataProjects = CoreDataProjects(moc: PersistenceController.shared.container.viewContext)
     @StateObject public var cvm: CoreDataNoteVersions = CoreDataNoteVersions(moc: PersistenceController.shared.container.viewContext)
     

--- a/DLPrototype/Views/Notes/NoteDashboard.swift
+++ b/DLPrototype/Views/Notes/NoteDashboard.swift
@@ -55,17 +55,6 @@ struct NoteDashboard: View {
     var body: some View {
         VStack(alignment: .leading) {
             VStack(alignment: .leading) {
-                HStack {
-                    Spacer()
-                    FancyButtonv2(
-                        text: "New note",
-                        action: {},
-                        icon: "plus",
-                        showLabel: false,
-                        redirect: AnyView(NoteCreate()),
-                        pageType: .notes
-                    )
-                }
                 SearchBar(
                     text: $searchText,
                     disabled: false,

--- a/DLPrototype/Views/Settings/Settings.swift
+++ b/DLPrototype/Views/Settings/Settings.swift
@@ -16,6 +16,7 @@ struct SettingsView: View {
 
     @Environment(\.managedObjectContext) var moc
     @EnvironmentObject public var ce: CoreDataCalendarEvent
+    @EnvironmentObject public var nav: Navigation
 
     var body: some View {
         TabView {
@@ -27,6 +28,7 @@ struct SettingsView: View {
             
             TodaySettings()
                 .environmentObject(ce)
+                .environmentObject(nav)
                 .tabItem {
                     Label("Today", systemImage: "doc.append.fill")
                 }

--- a/DLPrototype/Views/Settings/Settings.swift
+++ b/DLPrototype/Views/Settings/Settings.swift
@@ -15,6 +15,7 @@ struct SettingsView: View {
     }
 
     @Environment(\.managedObjectContext) var moc
+    @EnvironmentObject public var ce: CoreDataCalendarEvent
 
     var body: some View {
         TabView {
@@ -25,6 +26,7 @@ struct SettingsView: View {
                 .tag(Tabs.general)
             
             TodaySettings()
+                .environmentObject(ce)
                 .tabItem {
                     Label("Today", systemImage: "doc.append.fill")
                 }

--- a/DLPrototype/Views/Settings/Tabs/TodaySettings.swift
+++ b/DLPrototype/Views/Settings/Tabs/TodaySettings.swift
@@ -31,6 +31,8 @@ struct TodaySettings: View {
     
     @State private var calendars: [CustomPickerItem] = []
 
+    @EnvironmentObject public var ce: CoreDataCalendarEvent
+
     @Environment(\.managedObjectContext) var moc
 
     var body: some View {
@@ -117,9 +119,17 @@ struct TodaySettings: View {
                     }
                 }
 
-                Picker("Active calendar", selection: $calendar) {
-                    ForEach(calendars, id: \.self) { item in
-                        Text(item.title).tag(item.tag)
+                VStack(alignment: .trailing) {
+                    if calendar > -1 {
+                        Picker("Active calendar", selection: $calendar) {
+                            ForEach(calendars, id: \.self) { item in
+                                Text(item.title).tag(item.tag)
+                            }
+                        }
+                    } else {
+                        Button("Request access to calendar") {
+                            ce.requestAccess()
+                        }
                     }
                 }
             }

--- a/DLPrototype/Views/Settings/Tabs/TodaySettings.swift
+++ b/DLPrototype/Views/Settings/Tabs/TodaySettings.swift
@@ -32,6 +32,7 @@ struct TodaySettings: View {
     @State private var calendars: [CustomPickerItem] = []
 
     @EnvironmentObject public var ce: CoreDataCalendarEvent
+    @EnvironmentObject public var nav: Navigation
 
     @Environment(\.managedObjectContext) var moc
 


### PR DESCRIPTION
* Actually displays events now (if you have any)
* Lists the events of the day, ignoring items with "busy" in the title
* Dashboard.Header is aware of calendar changes and updates appropriately