### PR TITLE
Planning: add task note buttons

### DIFF
--- a/DLPrototype/Views/Jobs/JobCreate.swift
+++ b/DLPrototype/Views/Jobs/JobCreate.swift
@@ -141,9 +141,6 @@ extension JobCreate {
         newJob.lastUpdate = newJob.created
         job = newJob
 
-        PersistenceController.shared.save()
-
-        // TODO: workaround is to redirect to project instead
         if validProject {
             if let proj = project {
                 proj.addToJobs(newJob)
@@ -155,6 +152,8 @@ extension JobCreate {
                 nav.setSidebar(AnyView(JobDashboardSidebar()))
             }
         }
+
+        PersistenceController.shared.save()
     }
 
     private func colourPickerChange(colour: [Double]) -> Void {

--- a/DLPrototype/Views/Planning/Header.swift
+++ b/DLPrototype/Views/Planning/Header.swift
@@ -38,6 +38,33 @@ extension Planning {
                     }
 
                     Spacer()
+                    if numChildren > 0 {
+                        if type == .tasks {
+                            FancyButtonv2(
+                                text: "Add a task to this job",
+                                icon: "plus",
+                                fgColour: colour.isBright() ? .black : .white,
+                                showLabel: false,
+                                size: .link,
+                                type: .clear,
+                                redirect: AnyView(TaskDashboard(defaultSelectedJob: job)),
+                                pageType: .tasks,
+                                sidebar: AnyView(TaskDashboardSidebar())
+                            )
+                        } else if type == .notes {
+                            FancyButtonv2(
+                                text: "Add a note to this job",
+                                icon: "plus",
+                                fgColour: colour.isBright() ? .black : .white,
+                                showLabel: false,
+                                size: .link,
+                                type: .clear,
+                                redirect: AnyView(NoteDashboard()),
+                                pageType: .notes,
+                                sidebar: AnyView(NoteDashboardSidebar())
+                            )
+                        }
+                    }
                 }
                 .padding(10)
             }

--- a/DLPrototype/Views/Tasks/TaskGroup.swift
+++ b/DLPrototype/Views/Tasks/TaskGroup.swift
@@ -33,7 +33,7 @@ struct TaskGroup: View {
                     }
 
                     FancyButtonv2(
-                        text: project.name!,
+                        text: String(key.id_int()),
                         action: minimize,
                         icon: minimized ? "plus" : "minus",
                         fgColour: minimized ? (colour.isBright() ? .black : .white) : .white,


### PR DESCRIPTION
* Add new note/task button to planning row, displays when the job already has tasks or notes
* Task selector widget on Today now uses job IDs as titles instead of the project ID. This is the first of several changes coming to this widget.
* Minor bug fixes