### PR TITLE
New Experimental Feature: Spotlight extension

### DIFF
--- a/DLPrototype.xcodeproj/project.pbxproj
+++ b/DLPrototype.xcodeproj/project.pbxproj
@@ -193,6 +193,7 @@
 		53EFCE7629637CC6004E45EC /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53EFCE7529637CC6004E45EC /* Color.swift */; };
 		53EFCE7929637F35004E45EC /* GeneralSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53EFCE7829637F35004E45EC /* GeneralSettings.swift */; };
 		53EFCE7B29637F49004E45EC /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53EFCE7A29637F49004E45EC /* Settings.swift */; };
+		53F0C70D2BF04625000BFD2E /* CoreSpotlight.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 53F0C70C2BF04625000BFD2E /* CoreSpotlight.framework */; };
 		53F10FE0296E77BE0048D040 /* CoreDataJob.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53F10FDF296E77BE0048D040 /* CoreDataJob.swift */; };
 		53F5895E2998330000843B32 /* NoteResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53F5895D2998330000843B32 /* NoteResult.swift */; };
 		53F589602998335A00843B32 /* NoteRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53F5895F2998335A00843B32 /* NoteRow.swift */; };
@@ -417,6 +418,7 @@
 		53EFCE7529637CC6004E45EC /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
 		53EFCE7829637F35004E45EC /* GeneralSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettings.swift; sourceTree = "<group>"; };
 		53EFCE7A29637F49004E45EC /* Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Settings.swift; sourceTree = "<group>"; };
+		53F0C70C2BF04625000BFD2E /* CoreSpotlight.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreSpotlight.framework; path = System/Library/Frameworks/CoreSpotlight.framework; sourceTree = SDKROOT; };
 		53F10FDF296E77BE0048D040 /* CoreDataJob.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataJob.swift; sourceTree = "<group>"; };
 		53F5895D2998330000843B32 /* NoteResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteResult.swift; sourceTree = "<group>"; };
 		53F5895F2998335A00843B32 /* NoteRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteRow.swift; sourceTree = "<group>"; };
@@ -434,6 +436,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				53F0C70D2BF04625000BFD2E /* CoreSpotlight.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -515,6 +518,7 @@
 				53218D5F24B7F6EC0088ABE9 /* DLPrototypeTests */,
 				53218D6A24B7F6EC0088ABE9 /* DLPrototypeUITests */,
 				53218D4524B7F6EB0088ABE9 /* Products */,
+				53F0C70B2BF04624000BFD2E /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -1126,6 +1130,14 @@
 				53790C132A758A7200D3FFD4 /* RecordTableColumn.swift */,
 			);
 			path = LogTable;
+			sourceTree = "<group>";
+		};
+		53F0C70B2BF04624000BFD2E /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				53F0C70C2BF04625000BFD2E /* CoreSpotlight.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */

--- a/DLPrototype/DLPrototype.swift
+++ b/DLPrototype/DLPrototype.swift
@@ -14,11 +14,11 @@ struct DLPrototype: App {
     private let persistenceController = PersistenceController.shared
     @StateObject public var updater: ViewUpdater = ViewUpdater()
     @StateObject public var nav: Navigation = Navigation()
-    
+
     @State private var searching: Bool = false
-    
+
     @Environment(\.scenePhase) var scenePhase
-    
+
     var body: some Scene {
         WindowGroup {
             Home()
@@ -37,28 +37,28 @@ struct DLPrototype: App {
         }
         // TODO: still shows the window close/minimize/zoom,
         // see https://stackoverflow.com/questions/70501890/how-can-i-hide-title-bar-in-swiftui-for-macos-app
-//        .windowStyle(.hiddenTitleBar)
+        //        .windowStyle(.hiddenTitleBar)
         .commands {
             MainMenu(moc: persistenceController.container.viewContext, nav: nav)
         }
 
-        #if os(macOS)
+#if os(macOS)
         Settings {
             SettingsView()
                 .environment(\.managedObjectContext, persistenceController.container.viewContext)
                 .environmentObject(nav)
         }
-        
+
         // TODO: temp commented out, too early to include this
         MenuBarExtra("name", systemImage: "clock.fill") {
             let appName = Bundle.main.infoDictionary?["CFBundleDisplayName"] as? String
             // @TODO: temp commented out until I build a compatible search view
-//            FindDashboard(searching: $searching)
-//                .environmentObject(nav)
-//            Button("Quick Record") {
-//                print("TODO: implement quick record")
-//            }.keyboardShortcut("1")
-            
+            //            FindDashboard(searching: $searching)
+            //                .environmentObject(nav)
+            //            Button("Quick Record") {
+            //                print("TODO: implement quick record")
+            //            }.keyboardShortcut("1")
+
             Button("Search") {
                 nav.setView(AnyView(Dashboard()))
                 nav.setSidebar(AnyView(DashboardSidebar()))
@@ -70,18 +70,18 @@ struct DLPrototype: App {
                 NSApplication.shared.terminate(nil)
             }.keyboardShortcut("q")
         }
-//        .menuBarExtraStyle(.window)
-        #endif
+        //        .menuBarExtraStyle(.window)
+#endif
     }
 
     private func onAppear() -> Void {
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
         let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String
         let appName = Bundle.main.infoDictionary?["CFBundleDisplayName"] as? String
-        
+
         // https://github.com/lukakerr/NSWindowStyles
-//        NSApp?.mainWindow?.styleMask.remove(.titled)
-//        NSApp.presentationOptions.remove(.titled)
+        //        NSApp?.mainWindow?.styleMask.remove(.titled)
+        //        NSApp.presentationOptions.remove(.titled)
 
         nav.title = "\(appName ?? "DLPrototype") \(version ?? "0").\(build ?? "0")"
         nav.session.plan = CoreDataPlan(moc: persistenceController.container.viewContext).forDate(nav.session.date).first
@@ -96,6 +96,10 @@ struct DLPrototype: App {
         }
     }
 
+    func application(application: any App, continueUserActivity userActivity: NSUserActivity, restorationHandler: ([AnyObject]?) -> Void) -> Bool {
+        return true
+    }
+
     private func handleSpotlight(userActivity: NSUserActivity) {
         guard let uniqueIdentifier = userActivity.userInfo?[CSSearchableItemActivityIdentifier] as? String else {
             return
@@ -104,6 +108,6 @@ struct DLPrototype: App {
         // Handle spotlight interaction
         // Maybe deep-link, or something else entirely
         // This totally depends on your app's use-case
-        print("Item tapped: \(uniqueIdentifier)")
+        print("[debug][Spotlight] Item tapped: \(uniqueIdentifier)")
     }
 }

--- a/DLPrototype/DLPrototype.swift
+++ b/DLPrototype/DLPrototype.swift
@@ -7,6 +7,7 @@
 //
 
 import SwiftUI
+import CoreSpotlight
 
 @main
 struct DLPrototype: App {
@@ -26,6 +27,7 @@ struct DLPrototype: App {
                 .environmentObject(nav)
                 .onAppear(perform: onAppear)
                 .defaultAppStorage(.standard)
+                .onContinueUserActivity(CSSearchableItemActionType, perform: handleSpotlight)
                 .onChange(of: scenePhase) { phase in
                     if phase == .background || phase == .inactive {
                         // @TODO: serialize/deserialize previous session data here
@@ -92,5 +94,16 @@ struct DLPrototype: App {
             nav.planning.companies = plan.companies as! Set<Company>
             nav.planning.id = plan.id!
         }
+    }
+
+    private func handleSpotlight(userActivity: NSUserActivity) {
+        guard let uniqueIdentifier = userActivity.userInfo?[CSSearchableItemActivityIdentifier] as? String else {
+            return
+        }
+
+        // Handle spotlight interaction
+        // Maybe deep-link, or something else entirely
+        // This totally depends on your app's use-case
+        print("Item tapped: \(uniqueIdentifier)")
     }
 }

--- a/DLPrototype/Info.plist
+++ b/DLPrototype/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CoreSpotlightContinuation</key>
+	<true/>
+	<key>CFBundleGetInfoString</key>
+	<string></string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>

--- a/DLPrototype/Info.plist
+++ b/DLPrototype/Info.plist
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CoreSpotlightContinuation</key>
-	<true/>
-	<key>CFBundleGetInfoString</key>
-	<string></string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>

--- a/DLPrototype/Views/Settings/Tabs/GeneralSettings.swift
+++ b/DLPrototype/Views/Settings/Tabs/GeneralSettings.swift
@@ -107,6 +107,7 @@ extension GeneralSettings {
 
     private func spotlightIndexer(error: (any Error)?) -> Void {
         print("[debug][Spotlight] ERROR: \(error)")
+        print("[debug][Spotlight] Other")
     }
 }
 

--- a/DLPrototype/Views/Settings/Tabs/GeneralSettings.swift
+++ b/DLPrototype/Views/Settings/Tabs/GeneralSettings.swift
@@ -85,7 +85,7 @@ extension GeneralSettings {
     private func index() -> Void {
         var searchableItems = [CSSearchableItem]()
         let moc = PersistenceController.shared.container.viewContext
-        let data = CoreDataJob(moc: moc).all().filter({$0.title != nil && $0.id != nil})
+        let data = CoreDataJob(moc: moc).all(fetchLimit: 20).filter({$0.title != nil && $0.id != nil})
 
         for job in data {
             let attributeSet = CSSearchableItemAttributeSet(contentType: .plainText)


### PR DESCRIPTION
Enabling experimental features, then enabling "Spotlight", allows you to test the Spotlight indexing integration. 

Spotlight is a local-only search engine that does not share search data with anyone, not even Apple (if you take them at their word). In this state it will only attempt to take 20 items whose title and ID properties are set.  In the future I think it could be useful to have the Spotlight index data periodically cleared and rebuilt every couple weeks (maybe it could be configurable).